### PR TITLE
Updates poms and kotlin code gen processor to support tests.

### DIFF
--- a/kotlin-codegen/compiler/pom.xml
+++ b/kotlin-codegen/compiler/pom.xml
@@ -7,6 +7,7 @@
     <groupId>com.squareup.moshi</groupId>
     <artifactId>moshi-parent</artifactId>
     <version>1.6.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>moshi-kotlin-codegen-compiler</artifactId>
@@ -60,6 +61,7 @@
       <plugin>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
         <executions>
           <execution>
             <id>compile</id>

--- a/kotlin-codegen/integration-test/pom.xml
+++ b/kotlin-codegen/integration-test/pom.xml
@@ -7,6 +7,7 @@
     <groupId>com.squareup.moshi</groupId>
     <artifactId>moshi-parent</artifactId>
     <version>1.6.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>moshi-kotlin-codegen-integration</artifactId>

--- a/kotlin-codegen/integration-test/src/test/java/com/squareup/moshi/KotlinCodeGenTest.kt
+++ b/kotlin-codegen/integration-test/src/test/java/com/squareup/moshi/KotlinCodeGenTest.kt
@@ -617,7 +617,7 @@ class KotlinCodeGenTest {
       fail()
     } catch (e: IllegalArgumentException) {
       assertThat(e).hasMessage(
-          "Cannot serialize inner class com.squareup.moshi.KotlinJsonAdapterTest\$InnerClass")
+          "Cannot serialize non-static nested class com.squareup.moshi.KotlinCodeGenTest\$InnerClass")
     }
   }
 

--- a/kotlin-codegen/runtime/pom.xml
+++ b/kotlin-codegen/runtime/pom.xml
@@ -7,6 +7,7 @@
     <groupId>com.squareup.moshi</groupId>
     <artifactId>moshi-parent</artifactId>
     <version>1.6.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>moshi-kotlin-codegen-runtime</artifactId>
@@ -38,6 +39,7 @@
       <plugin>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
         <executions>
           <execution>
             <id>compile</id>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -47,6 +47,7 @@
       <plugin>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
         <executions>
           <execution>
             <id>compile</id>


### PR DESCRIPTION
Tests are running, though they don't pass.  It's generating source for the one test file that's annotated, but I'm not sure what you expect from the others.

It looks like Eugenio filed a [bug](https://youtrack.jetbrains.com/issue/KT-14070) a while back about the `kapt.kotlin.generated` option no longer being present in the kapt2 plugin.  That was [fixed](https://github.com/jetbrains/kotlin/commit/4a2e40994848883cc7007485dc87d1ab449e45d2) for the gradle plugin, but wasn't fixed for the maven plugin.  I've filed a [bug](https://youtrack.jetbrains.com/issue/KT-22783) for this.

I've also put a very hacky workaround in that should work until this is fixed.  Like I said, it's generating sources, it just isn't pretty. 